### PR TITLE
simplify merge if statement

### DIFF
--- a/bpe_base.py
+++ b/bpe_base.py
@@ -31,7 +31,7 @@ def merge(ids, pair, idx):
     i = 0
     while i < len(ids):
         # if not at the very last position AND the pair matches, replace it
-        if ids[i] == pair[0] and i < len(ids) - 1 and ids[i+1] == pair[1]:
+        if i < len(ids) - 1 and (ids[i], ids[i+1]) == pair:
             newids.append(idx)
             i += 2
         else:


### PR DESCRIPTION
Could even do this:
```Python
def merge(ids, pair, idx):
    newids = []
    i = 0
    pair = list(pair)

    while i < len(ids):
        if ids[i:i+2] == pair:
            newids.append(idx)
            i += 2
        else:
            newids.append(ids[i])
            i += 1
    return newids
```
But this leans on the fact that Python allows slices to go out of bounds. The last slice might be length 1. Might cause confusion to people from different languages.