### PR TITLE
Time Optimization of the train Method in RegexTokenizer

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -10,12 +10,13 @@ import unicodedata
 # -----------------------------------------------------------------------------
 # a few helper functions useful for both BasicTokenizer and RegexTokenizer
 
-def get_stats(ids):
+def get_stats(ids, counts=None):
     """
     Given a list of integers, return a dictionary of counts of consecutive pairs
     Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
     """
-    counts = {}
+    if counts is None:
+        counts = {}
     for pair in zip(ids, ids[1:]): # iterate consecutive elements
         counts[pair] = counts.get(pair, 0) + 1
     return counts

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -41,13 +41,10 @@ class RegexTokenizer(Tokenizer):
         merges = {} # (int, int) -> int
         vocab = {idx: bytes([idx]) for idx in range(256)} # idx -> bytes
         for i in range(num_merges):
-            # count up the number of times every consecutive pair appears
-            chunk_stats = [get_stats(chunk_ids) for chunk_ids in ids]
-            # combine the pair counts from all chunks by summing them up
             stats = {}
-            for chstat in chunk_stats:
-                for pair, count in chstat.items():
-                    stats[pair] = stats.get(pair, 0) + count
+            # count up the number of times every consecutive pair appears
+            # combine the pair counts from all chunks by summing them up
+            [get_stats(chunk_ids, stats) for chunk_ids in ids]
             # find the pair with the highest count
             pair = max(stats, key=stats.get)
             # mint a new token: assign it the next available id


### PR DESCRIPTION
Testing "train.py" on M2 Ultra, the time consumption was reduced from 21s to 16s after modification.