### PR TITLE
changed test_strings into a function decorated with @pytest.fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 .DS_Store
 models/**/*
+*.vocab
+*.model

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -6,14 +6,16 @@ from minbpe import BasicTokenizer, RegexTokenizer, GPT4Tokenizer
 
 # -----------------------------------------------------------------------------
 # common test data
+@pytest.fixture
+def test_strings():
+    # a few strings to test the tokenizers on
+    return [
+        "", # empty string
+        "?", # single character
+        "hello world!!!? (안녕하세요!) lol123 😉", # fun small string
+        "FILE:taylorswift.txt", # FILE: is handled as a special string in unpack()
+    ]
 
-# a few strings to test the tokenizers on
-test_strings = [
-    "", # empty string
-    "?", # single character
-    "hello world!!!? (안녕하세요!) lol123 😉", # fun small string
-    "FILE:taylorswift.txt", # FILE: is handled as a special string in unpack()
-]
 def unpack(text):
     # we do this because `pytest -v .` prints the arguments to console, and we don't
     # want to print the entire contents of the file, it creates a mess. So here we go.
@@ -50,23 +52,23 @@ The ancestors of llamas are thought to have originated from the Great Plains of 
 
 # test encode/decode identity for a few different strings
 @pytest.mark.parametrize("tokenizer_factory", [BasicTokenizer, RegexTokenizer, GPT4Tokenizer])
-@pytest.mark.parametrize("text", test_strings)
-def test_encode_decode_identity(tokenizer_factory, text):
-    text = unpack(text)
-    tokenizer = tokenizer_factory()
-    ids = tokenizer.encode(text)
-    decoded = tokenizer.decode(ids)
-    assert text == decoded
+def test_encode_decode_identity(tokenizer_factory, test_strings):
+    for text in test_strings:
+        text = unpack(text)
+        tokenizer = tokenizer_factory()
+        ids = tokenizer.encode(text)
+        decoded = tokenizer.decode(ids)
+        assert text == decoded
 
 # test that our tokenizer matches the official GPT-4 tokenizer
-@pytest.mark.parametrize("text", test_strings)
-def test_gpt4_tiktoken_equality(text):
-    text = unpack(text)
-    tokenizer = GPT4Tokenizer()
-    enc = tiktoken.get_encoding("cl100k_base")
-    tiktoken_ids = enc.encode(text)
-    gpt4_tokenizer_ids = tokenizer.encode(text)
-    assert gpt4_tokenizer_ids == tiktoken_ids
+def test_gpt4_tiktoken_equality(test_strings):
+    for text in test_strings:
+        text = unpack(text)
+        tokenizer = GPT4Tokenizer()
+        enc = tiktoken.get_encoding("cl100k_base")
+        tiktoken_ids = enc.encode(text)
+        gpt4_tokenizer_ids = tokenizer.encode(text)
+        assert gpt4_tokenizer_ids == tiktoken_ids
 
 # test the handling of special tokens
 def test_gpt4_tiktoken_equality_special_tokens():


### PR DESCRIPTION
changed the test_strings list into a function returning the string and decorated it with @pytest.fixtures so that we can avoid parametrizing it, also updated the .gitignore to avoid files of type *.model *.vocab, as such files are created while running quick.py

passed all test cases after updating
<img width="888" alt="image" src="https://github.com/karpathy/minbpe/assets/98260036/8dc0526c-ebab-4601-8da4-95de9ce1e9ac">
