### PR TITLE
suggestion: use counter

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -7,9 +7,11 @@ some concessions are made for simplicity.
 """
 import unicodedata
 from collections import Counter
+from itertools import pairwise
 
 # -----------------------------------------------------------------------------
 # a few helper functions useful for both BasicTokenizer and RegexTokenizer
+
 
 def get_stats(ids, counts=None) -> Counter:
     """
@@ -18,9 +20,9 @@ def get_stats(ids, counts=None) -> Counter:
     Optionally allows to update an existing dictionary of counts
     """
     if counts is None:
-        return Counter(zip(ids, ids[1:]))
+        return Counter(pairwise(ids))
 
-    counts.update(zip(ids, ids[1:]))
+    counts.update(pairwise(ids))
 
 
 def merge(ids, pair, idx):

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -17,10 +17,10 @@ def get_stats(ids, counts=None) -> Counter:
     Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
     Optionally allows to update an existing dictionary of counts
     """
-    counts = counts if counts is not None else Counter()
-    for pair in zip(ids, ids[1:]):  # iterate consecutive elements
-        counts.update({pair: 1})
-    return counts
+    c = Counter(zip(ids, ids[1:]))
+    if counts is not None:
+        c.update(counts)
+    return c
 
 
 def merge(ids, pair, idx):

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -17,10 +17,10 @@ def get_stats(ids, counts=None) -> Counter:
     Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
     Optionally allows to update an existing dictionary of counts
     """
-    c = Counter(zip(ids, ids[1:]))
-    if counts is not None:
-        c.update(counts)
-    return c
+    if counts is None:
+        return Counter(zip(ids, ids[1:]))
+
+    counts.update(zip(ids, ids[1:]))
 
 
 def merge(ids, pair, idx):

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -10,15 +10,15 @@ import unicodedata
 # -----------------------------------------------------------------------------
 # a few helper functions useful for both BasicTokenizer and RegexTokenizer
 
-def get_stats(ids, counts=None):
+def get_stats(ids, counts=None) -> Counter:
     """
     Given a list of integers, return a dictionary of counts of consecutive pairs
     Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
     Optionally allows to update an existing dictionary of counts
     """
-    counts = {} if counts is None else counts
-    for pair in zip(ids, ids[1:]): # iterate consecutive elements
-        counts[pair] = counts.get(pair, 0) + 1
+    counts = counts if counts is not None else Counter()
+    for pair in zip(ids, ids[1:]):  # iterate consecutive elements
+        counts.update({pair: 1})
     return counts
 
 

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -6,6 +6,7 @@ e.g. isolating all regex/pattern parts to the RegexTokenizer, but
 some concessions are made for simplicity.
 """
 import unicodedata
+from collections import Counter
 
 # -----------------------------------------------------------------------------
 # a few helper functions useful for both BasicTokenizer and RegexTokenizer

--- a/minbpe/basic.py
+++ b/minbpe/basic.py
@@ -32,7 +32,7 @@ class BasicTokenizer(Tokenizer):
             # count up the number of times every consecutive pair appears
             stats = get_stats(ids)
             # find the pair with the highest count
-            pair = max(stats, key=stats.get)
+            pair = stats.most_common(1)[0][0]
             # mint a new token: assign it the next available id
             idx = 256 + i
             # replace all occurrences of pair in ids with idx

--- a/minbpe/basic.py
+++ b/minbpe/basic.py
@@ -61,7 +61,7 @@ class BasicTokenizer(Tokenizer):
         while len(ids) >= 2:
             # find the pair with the lowest merge index
             stats = get_stats(ids)
-            pair = min(stats, key=lambda p: self.merges.get(p, float("inf")))
+            pair = stats.most_common()[:-2:-1]  # get the last element
             # subtle: if there are no more merges available, the key will
             # result in an inf for every single pair, and the min will be
             # just the first pair in the list, arbitrarily

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -52,7 +52,7 @@ class RegexTokenizer(Tokenizer):
             stats = Counter()
             for chunk_ids in ids:
                 # passing in stats will update it in place, adding up counts
-                stats = get_stats(chunk_ids, stats)
+                get_stats(chunk_ids, stats)
             # find the pair with the highest count
             pair = stats.most_common(1)[0][0]
             # mint a new token: assign it the next available id

--- a/train.py
+++ b/train.py
@@ -13,7 +13,6 @@ text = open("tests/taylorswift.txt", "r", encoding="utf-8").read()
 # create a directory for models, so we don't pollute the current directory
 os.makedirs("models", exist_ok=True)
 
-t0 = time.time()
 for TokenizerClass, name in zip([BasicTokenizer, RegexTokenizer], ["basic", "regex"]):
     # construct the Tokenizer object and kick off verbose training
     t0 = time.perf_counter()
@@ -24,5 +23,5 @@ for TokenizerClass, name in zip([BasicTokenizer, RegexTokenizer], ["basic", "reg
     tokenizer.save(prefix)
     t1 = time.perf_counter()
     print(f"Training {name} tokenizer took {t1 - t0:.2f} seconds")
-
-print(f"Training took {t1 - t0:.2f} seconds")
+    # > Training basic tokenizer took 3.56 seconds
+    # > Training regex tokenizer took 9.14 seconds

--- a/train.py
+++ b/train.py
@@ -15,13 +15,14 @@ os.makedirs("models", exist_ok=True)
 
 t0 = time.time()
 for TokenizerClass, name in zip([BasicTokenizer, RegexTokenizer], ["basic", "regex"]):
-
     # construct the Tokenizer object and kick off verbose training
+    t0 = time.perf_counter()
     tokenizer = TokenizerClass()
     tokenizer.train(text, 512, verbose=True)
     # writes two files in the models directory: name.model, and name.vocab
     prefix = os.path.join("models", name)
     tokenizer.save(prefix)
-t1 = time.time()
+    t1 = time.perf_counter()
+    print(f"Training {name} tokenizer took {t1 - t0:.2f} seconds")
 
 print(f"Training took {t1 - t0:.2f} seconds")

--- a/train.py
+++ b/train.py
@@ -17,11 +17,11 @@ for TokenizerClass, name in zip([BasicTokenizer, RegexTokenizer], ["basic", "reg
     # construct the Tokenizer object and kick off verbose training
     t0 = time.perf_counter()
     tokenizer = TokenizerClass()
-    tokenizer.train(text, 512, verbose=True)
+    tokenizer.train(text, 512, verbose=False)
     # writes two files in the models directory: name.model, and name.vocab
     prefix = os.path.join("models", name)
     tokenizer.save(prefix)
     t1 = time.perf_counter()
     print(f"Training {name} tokenizer took {t1 - t0:.2f} seconds")
-    # > Training basic tokenizer took 3.56 seconds
-    # > Training regex tokenizer took 9.14 seconds
+    # > Training basic tokenizer took 3.46 seconds
+    # > Training regex tokenizer took 8.84 seconds


### PR DESCRIPTION
I did not know this made a PR, but i'll leave some notes. 

```
> python3 train.py (use-counter)
Training basic tokenizer took 3.25 seconds
Training regex tokenizer took 7.92 seconds

> python3 train.py (main)
Training basic took 4.05 seconds
Training regex took 7.19 seconds
```

The overhead of counter updates makes it slower for regex case. Dict is likely faster overall, i might have to do with ammortization of growing dicts 