### PR TITLE
Optimise merge (~2x speedup)

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -28,17 +28,36 @@ def merge(ids, pair, idx):
     of pair with the new integer token idx
     Example: ids=[1, 2, 3, 1, 2], pair=(1, 2), idx=4 -> [4, 3, 4]
     """
-    newids = []
+    new_ids = [*ids]
+    return merge_inplace(new_ids, pair, idx)
+
+
+def merge_inplace(ids, pair, idx):
+    """
+    In the list of integers (ids), replace all consecutive occurrences
+    of pair with the new integer token idx.
+    This function modifies the ids array in-place.
+    Example: ids=[1, 2, 3, 1, 2], pair=(1, 2), idx=4 -> ids=[4, 3, 4]
+    """
+    p0, p1 = pair
+    increment = 2 if p0 != p1 else 1  # used when p1 matches, but p0 doesn't
+
     i = 0
-    while i < len(ids):
-        # if not at the very last position AND the pair matches, replace it
-        if ids[i] == pair[0] and i < len(ids) - 1 and ids[i+1] == pair[1]:
-            newids.append(idx)
-            i += 2
-        else:
-            newids.append(ids[i])
-            i += 1
-    return newids
+    while i < len(ids) - 1:
+        # check if the pair matches at this position
+        next_ch = ids[i + 1]
+        if next_ch != p1:
+            i += 2 if next_ch != p0 else 1
+            continue
+
+        if ids[i] != p0:
+            i += increment
+            continue
+
+        # replace pair with new token in-place
+        ids[i] = idx
+        ids.pop(i + 1)
+    return ids
 
 # first two helper functions...
 def replace_control_characters(s: str) -> str:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,24 @@
+import pytest
+
+from minbpe.base import merge
+
+
+def test_no_replacements():
+    assert merge([1, 2, 3], (2, 1), 4) == [1, 2, 3]
+
+def test_single_replacement():
+    assert merge([1, 2], (1, 2), 4) == [4]
+    assert merge([1, 2, 3], (1, 2), 4) == [4, 3]
+    assert merge([0, 1, 2], (1, 2), 4) == [0, 4]
+    assert merge([0, 1, 2, 3], (1, 2), 4) == [0, 4, 3]
+
+def test_multiple_replacements():
+    assert merge([1, 2, 3, 1, 2], (1, 2), 4) == [4, 3, 4]
+    assert merge([1, 1, 2, 1, 2], (1, 2), 4) == [1, 4, 4]
+
+def test_repeated_tokens():
+    assert merge([1, 2, 1, 1, 2], (1, 1), 4) == [1, 2, 4, 2]
+    assert merge([1, 1, 2, 1, 1, 1, 2], (1, 1), 4) == [4, 2, 4, 1, 2]
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
**TL;DR:** This PR reduces time spent merging from 17.8 seconds to 8.1 seconds when running `train.py` on my laptop.

## Changes

### 1. Modify array in-place

I have introduced a new method, `merge_inplace`, which modifies the ids array it is given instead of producing a new array. Additionally, I modified `merge` to copy the ids array and call `merge_inplace` on the copy, which is still quicker than the previous method (11.1 seconds spent merging when copying the array as well).

### 2. Algorithm improvements

I also made algorithm improvements so that we can skip more tokens while checking for pairs. I will try to explain why the changes work. It is probably best if you read the code before trying to understand this explanation though. Consider a pair (p0, p1) being matched against (m0, m1):
- If `p0 == p1` (e.g., "AA"), we have two cases:
  1. If `p1 != m1`, then `p0 != m1` as well. We can move forward by 2.
  2. If `p1 == m1`, then `p0 == m1` as well. We can only move forward by 1.

- If `p0 != p1` (e.g., "AB"), we have two cases:
  1. If `p1 != m1`, we can preemptively check whether `p0 != m1`, and potentially move forward by 2.
  2. If `p1 == m1` but `p0 != m0`, then `p0 != m1` (as we know p0 != p1). We can move forward by 2.

## Philosophy

I tried to keep the changes in plain Python to keep this minimal and readable. Alternatively, we could definitely optimise `merge` and `get_stats` a lot more using Numba and/or NumPy. Although, that might not fit with the spirit of this library.

## Testing

I have also added some tests for `merge` in `tests/test_merge.py`. 