### PR TITLE
Handle error when running out of pairs to merge

### DIFF
--- a/minbpe/basic.py
+++ b/minbpe/basic.py
@@ -31,18 +31,25 @@ class BasicTokenizer(Tokenizer):
         for i in range(num_merges):
             # count up the number of times every consecutive pair appears
             stats = get_stats(ids)
-            # find the pair with the highest count
-            pair = max(stats, key=stats.get)
-            # mint a new token: assign it the next available id
-            idx = 256 + i
-            # replace all occurrences of pair in ids with idx
-            ids = merge(ids, pair, idx)
-            # save the merge
-            merges[pair] = idx
-            vocab[idx] = vocab[pair[0]] + vocab[pair[1]]
-            # prints
-            if verbose:
-                print(f"merge {i+1}/{num_merges}: {pair} -> {idx} ({vocab[idx]}) had {stats[pair]} occurrences")
+
+            # if there's at least a mergeable pair
+            if len(stats):
+                # find the pair with the highest count
+                pair = max(stats, key=stats.get)
+                # mint a new token: assign it the next available id
+                idx = 256 + i
+                # replace all occurrences of pair in ids with idx
+                ids = merge(ids, pair, idx)
+                # save the merge
+                merges[pair] = idx
+                vocab[idx] = vocab[pair[0]] + vocab[pair[1]]
+                # prints
+                if verbose:
+                    print(f"merge {i+1}/{num_merges}: {pair} -> {idx} ({vocab[idx]}) had {stats[pair]} occurrences")
+            else:
+                if verbose:
+                    print(f"there aren't enough pairs to merge, stopping at {i}/{num_merges}")
+                break
 
         # save class variables
         self.merges = merges # used in encode()

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -52,18 +52,25 @@ class RegexTokenizer(Tokenizer):
             for chunk_ids in ids:
                 # passing in stats will update it in place, adding up counts
                 get_stats(chunk_ids, stats)
-            # find the pair with the highest count
-            pair = max(stats, key=stats.get)
-            # mint a new token: assign it the next available id
-            idx = 256 + i
-            # replace all occurrences of pair in ids with idx
-            ids = [merge(chunk_ids, pair, idx) for chunk_ids in ids]
-            # save the merge
-            merges[pair] = idx
-            vocab[idx] = vocab[pair[0]] + vocab[pair[1]]
-            # prints
-            if verbose:
-                print(f"merge {i+1}/{num_merges}: {pair} -> {idx} ({vocab[idx]}) had {stats[pair]} occurrences")
+
+            # if there's at least a mergeable pair
+            if len(stats):
+                # find the pair with the highest count
+                pair = max(stats, key=stats.get)
+                # mint a new token: assign it the next available id
+                idx = 256 + i
+                # replace all occurrences of pair in ids with idx
+                ids = [merge(chunk_ids, pair, idx) for chunk_ids in ids]
+                # save the merge
+                merges[pair] = idx
+                vocab[idx] = vocab[pair[0]] + vocab[pair[1]]
+                # prints
+                if verbose:
+                    print(f"merge {i+1}/{num_merges}: {pair} -> {idx} ({vocab[idx]}) had {stats[pair]} occurrences")
+            else:
+                if verbose:
+                    print(f"there aren't enough pairs to merge, stopping at {i}/{num_merges}")
+                break
 
         # save class variables
         self.merges = merges # used in encode()


### PR DESCRIPTION
Accidentally encountered a `ValueError: max() arg is an empty sequence` when attempting to test on a small piece of text with a (maybe) large `vocab_size`. 