### PR TITLE
Improved optimization strategy for 'Merge''

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -22,23 +22,38 @@ def get_stats(ids, counts=None):
     return counts
 
 
+
+
+
 def merge(ids, pair, idx):
     """
     In the list of integers (ids), replace all consecutive occurrences
     of pair with the new integer token idx
     Example: ids=[1, 2, 3, 1, 2], pair=(1, 2), idx=4 -> [4, 3, 4]
     """
+
+    if not ids:  # Early return for empty list
+        return []
+
     newids = []
     i = 0
-    while i < len(ids):
-        # if not at the very last position AND the pair matches, replace it
-        if ids[i] == pair[0] and i < len(ids) - 1 and ids[i+1] == pair[1]:
+    n = len(ids) - 1  # Adjust to pre-check the last element outside the loop
+
+    # Process until the second last element
+    while i < n:
+        if ids[i] == pair[0] and ids[i+1] == pair[1]:
             newids.append(idx)
-            i += 2
+            i += 2  # Skip the next element since it's part of the found pair
         else:
             newids.append(ids[i])
             i += 1
+    
+    # Handle the last element if i haven't reached it
+    if i == n:
+        newids.append(ids[i])
+    
     return newids
+
 
 # first two helper functions...
 def replace_control_characters(s: str) -> str:

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -6,6 +6,7 @@ e.g. isolating all regex/pattern parts to the RegexTokenizer, but
 some concessions are made for simplicity.
 """
 import unicodedata
+from collections import Counter
 
 # -----------------------------------------------------------------------------
 # a few helper functions useful for both BasicTokenizer and RegexTokenizer
@@ -21,7 +22,20 @@ def get_stats(ids, counts=None):
         counts[pair] = counts.get(pair, 0) + 1
     return counts
 
-
+def get_stats_basic(ids, counts=None):
+    """
+    Given a list of integers, return a dictionary of counts of consecutive pairs
+    Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
+    Optionally allows to update an existing dictionary of counts.
+    """
+    if counts is None:
+        counts = Counter()
+    else:
+        counts = Counter(counts)
+    
+    # Increment counts using Counter.update for consecutive pairs
+    counts.update(zip(ids, ids[1:]))
+    return dict(counts)
 
 
 

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -43,7 +43,7 @@ def merge(ids, pair, idx):
     while i < n:
         if ids[i] == pair[0] and ids[i+1] == pair[1]:
             newids.append(idx)
-            i += 2  # Skip the next element since it's part of the found pair
+            i += 2 
         else:
             newids.append(ids[i])
             i += 1

--- a/minbpe/basic.py
+++ b/minbpe/basic.py
@@ -9,7 +9,7 @@ But:
 - Does not handle any special tokens.
 """
 
-from .base import Tokenizer, get_stats, merge
+from .base import Tokenizer, get_stats_basic, merge
 
 
 class BasicTokenizer(Tokenizer):
@@ -23,16 +23,18 @@ class BasicTokenizer(Tokenizer):
 
         # input text preprocessing
         text_bytes = text.encode("utf-8") # raw bytes
-        ids = list(text_bytes) # list of integers in range 0..255
+        ids = bytearray(text_bytes) # list of integers in range 0..255
 
         # iteratively merge the most common pairs to create new tokens
         merges = {} # (int, int) -> int
         vocab = {idx: bytes([idx]) for idx in range(256)} # int -> bytes
         for i in range(num_merges):
             # count up the number of times every consecutive pair appears
-            stats = get_stats(ids)
+            stats = get_stats_basic(ids)
+            
             # find the pair with the highest count
             pair = max(stats, key=stats.get)
+
             # mint a new token: assign it the next available id
             idx = 256 + i
             # replace all occurrences of pair in ids with idx

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -41,7 +41,8 @@ class RegexTokenizer(Tokenizer):
         text_chunks = re.findall(self.compiled_pattern, text)
 
         # input text preprocessing
-        ids = [list(ch.encode("utf-8")) for ch in text_chunks]
+        # ids = [list(ch.encode("utf-8")) for ch in text_chunks]
+        ids = [bytearray(ch.encode("utf-8")) for ch in text_chunks]
 
         # iteratively merge the most common pairs to create new tokens
         merges = {} # (int, int) -> int
@@ -52,8 +53,10 @@ class RegexTokenizer(Tokenizer):
             for chunk_ids in ids:
                 # passing in stats will update it in place, adding up counts
                 get_stats(chunk_ids, stats)
+
             # find the pair with the highest count
             pair = max(stats, key=stats.get)
+            
             # mint a new token: assign it the next available id
             idx = 256 + i
             # replace all occurrences of pair in ids with idx


### PR DESCRIPTION
The optimization of the merge function aims to reduce computational overhead by adjusting loop execution to avoid unnecessary boundary checks. By calculating the list's length minus one, the loop now stops before the last element, sidestepping the need to constantly check if the current index is less than the list's length minus one. This small change leverages the fact that the last element cannot form a consecutive pair, thus minimizing comparison operations within the loop.