### PR TITLE
add `gnp/minbpe-rs` as community extensions in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ $ pytest -v .
 
 to run the tests. (-v is verbose, slightly prettier).
 
+## community extensions
+
+* [gnp/minbpe-rs](https://github.com/gnp/minbpe-rs): A Rust implementation of `minbpe` providing (near) one-to-one correspondence with the Python version
+
 ## exercise
 
 For those trying to study BPE, here is the advised progression exercise for how you can build your own minbpe step by step. See [exercise.md](exercise.md).


### PR DESCRIPTION
This PR adds the [gnp/minbpe-rs](https://github.com/gnp/minbpe-rs) project as a community extension of `minbpe` in the `README.md`. The project builds a Rust version of `minbpe` with similar APIs as that in the Python version.