### PR TITLE
Count only nonoverlapping occurences of a pair

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -17,8 +17,14 @@ def get_stats(ids, counts=None):
     Optionally allows to update an existing dictionary of counts
     """
     counts = {} if counts is None else counts
+    lastPair = None
     for pair in zip(ids, ids[1:]): # iterate consecutive elements
-        counts[pair] = counts.get(pair, 0) + 1
+        #check the pairs to not overlap, for example "aaa" has just one pair "aa"
+        if lastPair != pair:
+            lastPair = pair
+            counts[pair] = counts.get(pair, 0) + 1
+        else:
+            lastPair = None
     return counts
 
 


### PR DESCRIPTION
For example, you want to count 2 (not 4) occurrences of the pair 'aa' in text 'aaaaa', because merge() can replace it just 2 times. In other words the counted occurrences should not overlap. 

See the discussion in #51
`sentencepease` also implements it this way, per this [paper](https://arxiv.org/abs/2306.16837) (p. 3). 
