### PR TITLE
Link to Mojo port added

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ to run the tests. (-v is verbose, slightly prettier).
 ## community extensions
 
 * [gnp/minbpe-rs](https://github.com/gnp/minbpe-rs): A Rust implementation of `minbpe` providing (near) one-to-one correspondence with the Python version
+* [dorjeduck/minbpe.mojo](https://github.com/dorjeduck/minbpe.mojo): A Mojo implementation of `minbpe` 
 
 ## exercise
 


### PR DESCRIPTION
I've added a link to a Mojo port of minbpe. While this port functionally mirrors minbpe, it has a different design due to the current language constraints of Mojo, which include the absence of classes and inheritance.