### PR TITLE
calling len(ids) in merge() function only once to increase performance

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -29,10 +29,10 @@ def merge(ids, pair, idx):
     Example: ids=[1, 2, 3, 1, 2], pair=(1, 2), idx=4 -> [4, 3, 4]
     """
     newids = []
-    i = 0
-    while i < len(ids):
+    i = 0; lenids = len(ids)
+    while i < lenids:
         # if not at the very last position AND the pair matches, replace it
-        if ids[i] == pair[0] and i < len(ids) - 1 and ids[i+1] == pair[1]:
+        if ids[i] == pair[0] and i < lenids - 1 and ids[i+1] == pair[1]:
             newids.append(idx)
             i += 2
         else:


### PR DESCRIPTION
The length of input ids is not changing inside the `merge()` function. Instead of calling `len(ids)` in every iteration of the while loop, storing it in a variable at the beginning of the loop can help shave of few milliseconds while dealing with large documents.