### PR TITLE
Deduplication of text chunks with frequency count, training and encoding 5x speedup 

### DIFF
--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -12,8 +12,8 @@ import unicodedata
 
 def get_stats(ids, counts=None, weight=1):
     """
-    Given a list of integers, return a dictionary of counts of consecutive pairs
-    Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
+    Given a list of integers, return a dictionary of counts of consecutive pairs, multiplied by weight
+    Example: [1, 2, 3, 1, 2] -> {(1, 2): 2*weight, (2, 3): 1*weight, (3, 1): 1*weight}
     Optionally allows to update an existing dictionary of counts
     """
     counts = {} if counts is None else counts

--- a/minbpe/base.py
+++ b/minbpe/base.py
@@ -10,7 +10,7 @@ import unicodedata
 # -----------------------------------------------------------------------------
 # a few helper functions useful for both BasicTokenizer and RegexTokenizer
 
-def get_stats(ids, counts=None):
+def get_stats(ids, counts=None, weight=1):
     """
     Given a list of integers, return a dictionary of counts of consecutive pairs
     Example: [1, 2, 3, 1, 2] -> {(1, 2): 2, (2, 3): 1, (3, 1): 1}
@@ -18,7 +18,7 @@ def get_stats(ids, counts=None):
     """
     counts = {} if counts is None else counts
     for pair in zip(ids, ids[1:]): # iterate consecutive elements
-        counts[pair] = counts.get(pair, 0) + 1
+        counts[pair] = counts.get(pair, 0) + weight
     return counts
 
 

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -41,7 +41,16 @@ class RegexTokenizer(Tokenizer):
         text_chunks = re.findall(self.compiled_pattern, text)
 
         # input text preprocessing
-        ids = [list(ch.encode("utf-8")) for ch in text_chunks]
+        ids = (list(ch.encode("utf-8")) for ch in text_chunks)
+
+        #keep just one instance of identical chunks, keep their count in idsw
+        tmp = {}
+        for byte_str in ids:
+            byte_str = bytes(byte_str)
+            tmp[byte_str] = tmp[byte_str] + 1 if byte_str in tmp else 1
+
+        ids = [list(k) for k in map(list, tmp.keys())]
+        idsw = list(tmp.values())
 
         # iteratively merge the most common pairs to create new tokens
         merges = {} # (int, int) -> int
@@ -49,9 +58,9 @@ class RegexTokenizer(Tokenizer):
         for i in range(num_merges):
             # count the number of times every consecutive pair appears
             stats = {}
-            for chunk_ids in ids:
+            for j, chunk_ids in enumerate(ids):
                 # passing in stats will update it in place, adding up counts
-                get_stats(chunk_ids, stats)
+                get_stats(chunk_ids, stats, idsw[j])
             # find the pair with the highest count
             pair = max(stats, key=stats.get)
             # mint a new token: assign it the next available id

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -47,7 +47,7 @@ class RegexTokenizer(Tokenizer):
         tmp = {}
         for byte_str in ids:
             byte_str = bytes(byte_str)
-            tmp[byte_str] = tmp[byte_str] + 1 if byte_str in tmp else 1
+            tmp[byte_str] = tmp.get(byte_str, 0) + 1
 
         ids = [list(k) for k in map(list, tmp.keys())]
         idsw = list(tmp.values())

--- a/minbpe/regex.py
+++ b/minbpe/regex.py
@@ -119,14 +119,16 @@ class RegexTokenizer(Tokenizer):
 
     def encode_ordinary(self, text):
         """Encoding that ignores any special tokens."""
+        cache = {}
         # split text into chunks of text by categories defined in regex pattern
         text_chunks = re.findall(self.compiled_pattern, text)
         # all chunks of text are encoded separately, then results are joined
         ids = []
         for chunk in text_chunks:
-            chunk_bytes = chunk.encode("utf-8") # raw bytes
-            chunk_ids = self._encode_chunk(chunk_bytes)
-            ids.extend(chunk_ids)
+            if chunk not in cache:
+                chunk_bytes = chunk.encode("utf-8")  # raw bytes
+                cache[chunk] = self._encode_chunk(chunk_bytes)
+            ids.extend(cache[chunk])
         return ids
 
     def encode(self, text, allowed_special="none_raise"):


### PR DESCRIPTION
In `RegexTokenizer`, the training text is initially split into chunks, and further processing is performed on individual chunks. This PR optimizes the process by retaining only unique chunks and their corresponding frequency counts. Practically this cuts the number of chunks to 1/7th, resulting in a training speedup of at least 5x.

Similar optimization for encode_ordinary(), where the tokenization of each string is cached. Also 5x speedup.
